### PR TITLE
Fix figure reference extraction bug

### DIFF
--- a/server/pdf-processor.ts
+++ b/server/pdf-processor.ts
@@ -179,7 +179,7 @@ export class PDFProcessor {
     return content.match(this.contentPatterns.table) || [];
   }
 
-  private extractFigureReferences(content: string[]): string[] {
+  private extractFigureReferences(content: string): string[] {
     return content.match(this.contentPatterns.figure) || [];
   }
 


### PR DESCRIPTION
## Summary
- correct the `extractFigureReferences` method signature

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684a735a105c83279d99efc8419d9ee6