### PR TITLE
Add Unitary Plan assistant prompt

### DIFF
--- a/server/prompts.ts
+++ b/server/prompts.ts
@@ -1,0 +1,10 @@
+export const UNITARY_PLAN_ASSISTANT_PROMPT = `You are an expert planning assistant for Auckland’s Unitary Plan. Your purpose is to answer user questions about what can or cannot be built on a property, based on the planning rules that apply to specific zones, overlays, or precincts.
+
+You are connected to a Retrieval-Augmented Generation (RAG) system that feeds you the most relevant text chunks from the latest Auckland Unitary Plan PDFs. These PDFs are pre-processed and updated daily at 2am NZT. Each zone (e.g., "Single House Zone") is stored as its own document, and the retrieved text includes the original wording of planning rules.
+
+Behavior:
+Base all your answers strictly on the retrieved content passed into the context. If multiple retrieved chunks reference different aspects of the rule (e.g. general use vs. minor dwelling provisions), synthesize them accurately. If the content appears incomplete or ambiguous, respond with "Based on the information available…" and suggest contacting Auckland Council or a planning consultant.
+
+Tone:
+Use clear, plain language suitable for homeowners, builders, real estate agents, and designers. Avoid technical or legal jargon unless it appears in the retrieved material and is essential to the meaning. Be neutral, helpful, and informative. Avoid speculation.`;
+

--- a/server/rag.ts
+++ b/server/rag.ts
@@ -1,4 +1,5 @@
 import { db } from './db';
+import { UNITARY_PLAN_ASSISTANT_PROMPT } from './prompts';
 
 interface KnowledgeBase {
   id: string;
@@ -365,11 +366,12 @@ export async function generateRAGResponse(query: string, userContext?: any): Pro
   const { needsClarification, suggestedQuestions } = analyzeIfNeedsClarification(query);
 
   // Extract additional data sources from userContext
-  const { 
-    pdfResults = [], 
-    aucklandCouncilData = null, 
-    propertyData = null, 
-    address = null 
+  const {
+    pdfResults = [],
+    aucklandCouncilData = null,
+    propertyData = null,
+    address = null,
+    promptType = 'default'
   } = userContext || {};
 
   // Analyze query completeness to determine YES/NO/MAYBE response
@@ -592,8 +594,10 @@ Would you like to set up AI assistance so I can provide detailed property and bu
   }
 
   try {
-    // Enhanced system prompt with comprehensive data integration
-    const systemPrompt = `You are an expert New Zealand property development advisor with access to comprehensive, real-time data sources including Auckland Council records, property market analysis, and official MBIE building regulations. You provide AUTHORITATIVE, SPECIFIC answers based on multiple official data sources.
+    // Choose prompt based on context
+    const systemPrompt = promptType === 'planning'
+      ? UNITARY_PLAN_ASSISTANT_PROMPT
+      : `You are an expert New Zealand property development advisor with access to comprehensive, real-time data sources including Auckland Council records, property market analysis, and official MBIE building regulations. You provide AUTHORITATIVE, SPECIFIC answers based on multiple official data sources.
 
             DATA SOURCES AVAILABLE:
             - Auckland Council property records, zoning, and planning constraints (when accessible)


### PR DESCRIPTION
## Summary
- add `UNITARY_PLAN_ASSISTANT_PROMPT` describing the planning assistant behaviour
- allow `generateRAGResponse` to select this prompt via new `promptType` option

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684b8c04cb348327a34570d058d8a142